### PR TITLE
Update Readme: fix pxf build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ export GPHOME=/usr/local/cloudberry-db
 export PXF_HOME=/usr/local/pxf
 export PXF_BASE=${HOME}/pxf-base
 chown -R gpadmin:gpadmin "${GPHOME}" "${PXF_HOME}"
-make -C ~/workspace/pxf install
+make -C ~/workspace/cloudberry-db install
 ```
 
 NOTE: if `PXF_BASE` is not set, it will default to `PXF_HOME`, and server configurations, libraries or other configurations, might get deleted after a PXF re-install.


### PR DESCRIPTION
In the latest version of cloudberry(main branch), insall path has been change to '/usr/local/cloudberry-db' instead of  '/usr/local/cloudberry', so the steps of build pxf(main branch) should match with this.
