### PR TITLE
Fix: external table regress allow demo text resolver to handle multiple fields

### DIFF
--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
@@ -19,7 +19,6 @@ package org.greenplum.pxf.api;
  * under the License.
  */
 
-
 import org.greenplum.pxf.api.examples.DemoResolver;
 import org.greenplum.pxf.api.examples.DemoTextResolver;
 import org.greenplum.pxf.api.model.RequestContext;
@@ -79,7 +78,7 @@ public class DemoResolverTest {
 
     @Test
     public void testSetEmptyTextData() throws Exception {
-        OneField field = new OneField(VARCHAR.getOID(), new byte[]{});
+        OneField field = new OneField(VARCHAR.getOID(), new byte[] {});
         OneRow output = textResolver.setFields(Collections.singletonList(field));
         assertNull(output);
     }
@@ -97,16 +96,17 @@ public class DemoResolverTest {
     }
 
     @Test
-    public void testSetTextDataManyElements() {
-        assertThrows(Exception.class,
-                () -> textResolver.setFields(Arrays.asList(field, field)));
+    public void testSetTextDataManyElements() throws Exception {
+        OneRow output = textResolver.setFields(Arrays.asList(field, field));
+        assertArrayEquals("value1,value2,value1,value2\n".getBytes(),
+                (byte[]) output.getData());
     }
 
     @Test
     public void testSetFieldsIsUnsupported() {
-      Exception e = assertThrows(UnsupportedOperationException.class,
+        Exception e = assertThrows(UnsupportedOperationException.class,
                 () -> customResolver.setFields(null));
 
-      assertEquals("Demo resolver does not support write operation", e.getMessage());
+        assertEquals("Demo resolver does not support write operation", e.getMessage());
     }
 }


### PR DESCRIPTION




<!--Thank you for contributing! -->
<!--In case of an existing issue or discussions, please reference it-->

<!--Remove this section if no corresponding issue.-->

---

## Change logs

- adjust DemoTextResolver to serialize multi-column records by joining fields
- preserve legacy single-field end-of-stream semantics
- update DemoResolverTest expectation to cover multi-field output
## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) as a reference.
* Sign the Contributor License Agreement as prompted for your first-time contribution (*One-time setup*).
* Learn the [code contribution](https://cloudberrydb.org/contribute/code) and [doc contribution](https://cloudberrydb.org/contribute/doc) guides for better collaboration.
* List your communications in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb-site/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
* Feel free to ask for the cloudberrydb team to help review and approve.
