### PR TITLE
Add dependency-submission workflow to collect gradle dependencies

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,23 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [ 'main' ]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v5
+        with:
+          build-root-directory: server
+          artifact-retention-days: 5


### PR DESCRIPTION
### Gradle Dependency Submission for cloudberry-pxf

GitHub can collect[1] gradle dependencies on its own. However It fails to collect it when `build.gradle` is located in the nested directory.

Adding new github-action workflow that mimics what github doing automatically[2].

[1] https://github.blog/changelog/2025-05-27-dependency-auto-submission-now-supports-gradle/
[2] https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-automatic-dependency-submission-for-your-repository#gradle-projects
