### PR TITLE
Fix: Always run PXF Automation tests when PR created

### DIFF
--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -2,9 +2,8 @@ name: PXF CI Pipeline
 
 on:
   push:
-    branches: [ merge-with-upstream ]
+    branches: [ main ]
   pull_request:
-    branches: [ merge-with-upstream ]
     types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 


### PR DESCRIPTION
Current HEAD moved from `merge-with-upstream` to `main`. Adjust github actions to run CI:
* when commits pushed (merged) into `main`
* when PR to any (`main` or feature-branch) created/changed