### PR TITLE
CI: allow concurrent workflows on main branch

### DIFF
--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   JAVA_VERSION: "11"


### PR DESCRIPTION
Previously, CI workflows triggered by pushes to the main branch were grouped by `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. As a result, when multiple PRs were merged in a short period of time, a newly merged commit would cancel the CI workflow of the previous commit.

This change removes the cancellation behavior so that CI workflows for different commits on the main branch can run in parallel. This ensures that each merged commit is fully validated by CI and avoids losing test results due to automatic cancellation.

No changes to the CI steps themselves; only the workflow concurrency behavior is adjusted.

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-pxf/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.