### PR TITLE
CI: Add branch matrix to support testing on main and REL_2_STABLE

### DIFF
--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -54,7 +54,7 @@ jobs:
         export WORKSPACE=$PWD/workspace
         # Sanitize branch name for Debian version (replace _ with -)
         BRANCH_NAME="${{ matrix.cloudberry_branch }}"
-        CLEAN_BRANCH="${BRANCH_NAME//_/-}"
+        CLEAN_BRANCH=$(echo "$BRANCH_NAME" | tr '_' '-')
         export CLOUDBERRY_VERSION=99.0.0-${CLEAN_BRANCH}
         export CLOUDBERRY_BUILD=1
         bash cloudberry-pxf/ci/docker/pxf-cbdb-dev/ubuntu/script/build_cloudberry_deb.sh


### PR DESCRIPTION
Currently, the CI pipeline only targets the Cloudberry main branch. This commit enhances the workflow to support multi-branch testing by introducing a matrix strategy.

Key changes:
- Add cloudberry_branch matrix to build-cloudberry-deb and pxf-test jobs to run parallel workflows for main and REL_2_STABLE.
- Include the sanitized branch name in the DEB package version (e.g., 99.0.0-REL-2-STABLE) to differentiate artifacts.
- Update artifact upload/download paths to prevent collision between Or branches.
- Improve the test summary script to group and report results by Cloudberry branch.

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-pxf/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.