### PR TITLE
Release: add REL_2_STABLE branch support to CI

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -23,7 +23,7 @@ name: Dependency Submission
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ 'main', 'REL_2_STABLE' ]
 
 permissions:
   contents: write

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -23,7 +23,7 @@ name: PXF CI Pipeline
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, REL_2_STABLE ]
   pull_request:
     types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
@@ -40,7 +40,7 @@ env:
   JAVA_HOME: "/usr/lib/jvm/java-11-openjdk"
   GO_VERSION: "1.21"
   GPHOME: "/usr/local/cloudberry-db"
-  CLOUDBERRY_VERSION: "main"
+  CLOUDBERRY_VERSION: "REL_2_STABLE"
   PXF_HOME: "/usr/local/pxf"
 
 jobs:


### PR DESCRIPTION
- Add REL_2_STABLE branch to pxf-ci.yml and dependency-submission.yml workflows
- Update CLOUDBERRY_VERSION environment variable to REL_2_STABLE

This change enables testing and dependency submission for the REL_2_STABLE release branch.

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-pxf/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.