### PR TITLE
Fix release tarball base version naming

### DIFF
--- a/package/cloudberry-pxf-release.sh
+++ b/package/cloudberry-pxf-release.sh
@@ -518,16 +518,18 @@ section "Staging release: $TAG"
   export COPYFILE_DISABLE=1
   export COPY_EXTENDED_ATTRIBUTES_DISABLE=1
 
-  git archive --format=tar --prefix="apache-cloudberry-pxf-${TAG}/" "$TAG" | tar -x -C "$TMP_DIR"
+  # Keep -rcN in the artifact filename for RC voting, but keep the extracted
+  # top-level directory name as the main version (without -rcN).
+  git archive --format=tar --prefix="apache-cloudberry-pxf-${VERSION_FILE}/" "$TAG" | tar -x -C "$TMP_DIR"
 
   # Archive submodules if any
   if [ -s .gitmodules ]; then
     git submodule foreach --recursive --quiet "
       echo \"Archiving submodule: \$sm_path\"
       fullpath=\"\$toplevel/\$sm_path\"
-      destpath=\"$TMP_DIR/apache-cloudberry-pxf-$TAG/\$sm_path\"
+      destpath=\"$TMP_DIR/apache-cloudberry-pxf-${VERSION_FILE}/\$sm_path\"
       mkdir -p \"\$destpath\"
-      git -C \"\$fullpath\" archive --format=tar --prefix=\"\$sm_path/\" HEAD | tar -x -C \"$TMP_DIR/apache-cloudberry-pxf-$TAG\"
+      git -C \"\$fullpath\" archive --format=tar --prefix=\"\$sm_path/\" HEAD | tar -x -C \"$TMP_DIR/apache-cloudberry-pxf-${VERSION_FILE}\"
     "
   fi
 
@@ -536,25 +538,25 @@ section "Staging release: $TAG"
     echo "Cleaning macOS extended attributes from extracted files..."
     # Remove all extended attributes recursively
     if command -v xattr >/dev/null 2>&1; then
-      find "$TMP_DIR/apache-cloudberry-pxf-${TAG}" -type f -exec xattr -c {} \; 2>/dev/null || true
+      find "$TMP_DIR/apache-cloudberry-pxf-${VERSION_FILE}" -type f -exec xattr -c {} \; 2>/dev/null || true
       echo "[OK] Extended attributes cleaned using xattr"
     fi
     
     # Remove any ._* files that might have been created
-    find "$TMP_DIR/apache-cloudberry-pxf-${TAG}" -name '._*' -delete 2>/dev/null || true
-    find "$TMP_DIR/apache-cloudberry-pxf-${TAG}" -name '.DS_Store' -delete 2>/dev/null || true
-    find "$TMP_DIR/apache-cloudberry-pxf-${TAG}" -name '__MACOSX' -type d -exec rm -rf {} \; 2>/dev/null || true
+    find "$TMP_DIR/apache-cloudberry-pxf-${VERSION_FILE}" -name '._*' -delete 2>/dev/null || true
+    find "$TMP_DIR/apache-cloudberry-pxf-${VERSION_FILE}" -name '.DS_Store' -delete 2>/dev/null || true
+    find "$TMP_DIR/apache-cloudberry-pxf-${VERSION_FILE}" -name '__MACOSX' -type d -exec rm -rf {} \; 2>/dev/null || true
     echo "[OK] macOS-specific files removed"
   fi
 
   # Create tarball using the detected tar tool
   if [[ "$DETECTED_PLATFORM" == "macOS" ]]; then
     echo "Using GNU tar for cross-platform compatibility..."
-    $DETECTED_TAR_TOOL --exclude='._*' --exclude='.DS_Store' --exclude='__MACOSX' -czf "$TAR_NAME" -C "$TMP_DIR" "apache-cloudberry-pxf-${TAG}"
+    $DETECTED_TAR_TOOL --exclude='._*' --exclude='.DS_Store' --exclude='__MACOSX' -czf "$TAR_NAME" -C "$TMP_DIR" "apache-cloudberry-pxf-${VERSION_FILE}"
     echo "INFO: macOS detected - applied extended attribute cleanup and GNU tar"
   else
     # On other platforms, use standard tar
-    $DETECTED_TAR_TOOL -czf "$TAR_NAME" -C "$TMP_DIR" "apache-cloudberry-pxf-${TAG}"
+    $DETECTED_TAR_TOOL -czf "$TAR_NAME" -C "$TMP_DIR" "apache-cloudberry-pxf-${VERSION_FILE}"
   fi
   
   rm -rf "$TMP_DIR"


### PR DESCRIPTION
For RC tags like X.Y.Z-incubating-rcN, generate the source tarball filename and top-level directory using VERSION_FILE (without -rcN).

$VERSION_FILE is input from the file version.

This keeps the voted bits ready for promotion without rebuilding and avoids -rcN showing up in the extracted source directory.

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-pxf/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.