### PR TITLE
Fix Dependency submission workflow.

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -37,10 +37,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-      - uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 11
       - name: Download Gradle Wrapper Jar
         working-directory: ./server
         run: make prepare-gradle-wrapper


### PR DESCRIPTION
Add download `gradle-wrapper.jar` step to Dependency Submission workflowe. This should fix regression in workflow that was introduced recently.