### PR TITLE
Add procps-ng as RPM dependency to fix pxf stop command

### DIFF
--- a/package/DEBIAN/control
+++ b/package/DEBIAN/control
@@ -2,4 +2,5 @@ Package: apache-cloudberry-pxf-incubating
 Version: %VERSION%
 Architecture: %ARCH%
 Maintainer: %MAINTAINER%
+Depends: procps
 Description: Apache Cloudberry PXF (Platform Extension Framework) for advanced data access

--- a/package/cloudberry-pxf.spec
+++ b/package/cloudberry-pxf.spec
@@ -41,6 +41,7 @@ Prefix:   /usr/local/cloudberry-pxf-%{version}
 # management scripts
 
 Requires: bash
+Requires: procps-ng
 
 # Require Apache Cloudberry - .so file makes sense only when
 # installing on Cloudberry node, so inherit Cloudberry's dependencies


### PR DESCRIPTION
The pxf script uses the 'ps' command in the isRunning() function to check if the PXF process is running. However, minimal container images like Rocky Linux 9 do not include the 'ps' command by default.

This causes the 'pxf stop' command to fail with:
  /usr/local/cloudberry-pxf/bin/pxf: line 162: ps: command not found

Add explicit package dependencies to ensure the 'ps' command is available when PXF is installed:
- RPM packages: procps-ng
- DEB packages: procps

The 'ps' command is used in:
- server/pxf-service/src/scripts/pxf:162 (isRunning function)

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-pxf/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.