### PR TITLE
CI: cache deb and rpm for month

### DIFF
--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -95,6 +95,7 @@ jobs:
         tar czf cloudberry-source.tar.gz cloudberry/
 
     - name: Save DEB cache
+      # save cache from default branch only (this cache can be reused between PRs)
       if: steps.cache-deb.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache/save@v4
       with:
@@ -124,7 +125,7 @@ jobs:
       image: apache/incubator-cloudberry:cbdb-build-rocky9-latest
       options: --user root
     steps:
-    - name: Get week number
+    - name: Get month number
       id: get-month
       run: echo "month=$(/bin/date -u '+%Y-%m')" >> "$GITHUB_OUTPUT"
 
@@ -167,6 +168,7 @@ jobs:
         tar czf cloudberry-source-rocky9.tar.gz cloudberry/
 
     - name: Save RPM cache
+      # save cache from default branch only (this cache can be reused between PRs)
       if: steps.cache-rpm.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache/save@v4
       with:


### PR DESCRIPTION
**Cache CPU-heavy CI steps:**
* DEB build
* RPM build

This should speed up our CI pipelines and reduce github actions quota usage.

**Implementations details:**
* Github cache has 7 days TTL. Every build will reset expiration timeout. In order to force CI to build cloudberry from time to time - I am explicitly specifying current month in a cache key.
* keep both: `actions/cache` and `actions/actions/upload-artifact`. In case cache eviction happens during build (e.g. hit 10Gb limit) we will still have running builds.
* cache reused between `main` and other PRs (but not between PRs). So, cache will be filled only during builds in `main`.