### PR TITLE
CI: add caching for testcontainer images

### DIFF
--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -675,6 +675,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
+          cache: 'gradle'
 
       - name: Download pxf-cbdb testcontainer image
         uses: actions/download-artifact@v4

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -675,7 +675,6 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
-          cache: 'gradle'
 
       - name: Download pxf-cbdb testcontainer image
         uses: actions/download-artifact@v4

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -364,7 +364,6 @@ jobs:
       run: |
         cd cloudberry-pxf
         docker compose -f ci/docker/pxf-cbdb-dev/ubuntu/docker-compose.yml down -v || true
-        docker compose -f ci/docker/pxf-cbdb-dev/ubuntu/docker-compose.yml build
         docker compose -f ci/docker/pxf-cbdb-dev/ubuntu/docker-compose.yml up -d
         docker exec pxf-cbdb-dev sudo chown -R gpadmin:gpadmin /home/gpadmin/workspace/cloudberry
         docker cp /tmp/*.deb pxf-cbdb-dev:/tmp/
@@ -536,7 +535,6 @@ jobs:
       run: |
         cd cloudberry-pxf
         docker compose -f ci/docker/pxf-cbdb-dev/rocky9/docker-compose.yml down -v || true
-        docker compose -f ci/docker/pxf-cbdb-dev/rocky9/docker-compose.yml build
         docker compose -f ci/docker/pxf-cbdb-dev/rocky9/docker-compose.yml up -d
         docker exec pxf-cbdb-dev sudo chown -R gpadmin:gpadmin /home/gpadmin/workspace/cloudberry
         docker cp /tmp/*.rpm pxf-cbdb-dev:/tmp/

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -253,7 +253,7 @@ jobs:
         retention-days: 1
 
   build-pxf-cbdb-testcontainer-image:
-    name: Build PXF-CBDB Testcontainer Image (${{ matrix.distro }})
+    name: Build Testcontainer Images (${{ matrix.distro }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -265,24 +265,44 @@ jobs:
             base_image: apache/incubator-cloudberry:cbdb-build-rocky9-latest
             image_tag: pxf/cbdb-testcontainer-rocky9:1
     steps:
+      - name: Get month number
+        id: get-month
+        run: echo "month=$(/bin/date -u '+%Y-%m')" >> "$GITHUB_OUTPUT"
+
       - name: Checkout PXF source
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - name: Build pxf-cbdb testcontainer image
+      - name: Restore testcontainer image cache
+        id: cache-tc
+        uses: actions/cache/restore@v4
+        with:
+          path: pxf-cbdb-testcontainer-${{ matrix.distro }}.tar
+          key: pxf-cbdb-testcontainer-${{ matrix.distro }}-${{ steps.get-month.outputs.month }}-${{ hashFiles('automation/src/main/resources/testcontainers/pxf-cbdb/**') }}
+
+      - name: Build testcontainer images
+        if: steps.cache-tc.outputs.cache-hit != 'true'
         run: |
           docker build \
             --build-arg BASE_IMAGE=${{ matrix.base_image }} \
             -t ${{ matrix.image_tag }} \
             automation/src/main/resources/testcontainers/pxf-cbdb
-          docker save ${{ matrix.image_tag }} > /tmp/pxf-cbdb-testcontainer-${{ matrix.distro }}.tar
+          docker save ${{ matrix.image_tag }} > "${GITHUB_WORKSPACE}/pxf-cbdb-testcontainer-${{ matrix.distro }}.tar"
 
-      - name: Upload pxf-cbdb testcontainer image
+      - name: Save testcontainer image cache
+        # save cache from default branch only (reuse between PRs for the same month and context)
+        if: steps.cache-tc.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: pxf-cbdb-testcontainer-${{ matrix.distro }}.tar
+          key: pxf-cbdb-testcontainer-${{ matrix.distro }}-${{ steps.get-month.outputs.month }}-${{ hashFiles('automation/src/main/resources/testcontainers/pxf-cbdb/**') }}
+
+      - name: Upload testcontainer images
         uses: actions/upload-artifact@v4
         with:
           name: pxf-cbdb-testcontainer-image-${{ matrix.distro }}
-          path: /tmp/pxf-cbdb-testcontainer-${{ matrix.distro }}.tar
+          path: pxf-cbdb-testcontainer-${{ matrix.distro }}.tar
           retention-days: 1
 
   # Stage 2: Parallel test jobs using matrix strategy

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -260,7 +260,7 @@ jobs:
         include:
           - distro: ubuntu
             base_image: apache/incubator-cloudberry:cbdb-build-ubuntu22.04-latest
-            image_tag: pxf/cbdb-testcontainer:1
+            image_tag: pxf/cbdb-testcontainer-ubuntu:1
           - distro: rocky9
             base_image: apache/incubator-cloudberry:cbdb-build-rocky9-latest
             image_tag: pxf/cbdb-testcontainer-rocky9:1

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -27,5 +27,5 @@ parquetVersion=1.15.2
 awsJavaSdk=1.12.261
 springBootVersion=2.7.18
 org.gradle.daemon=true
-org.gradle.parallel=false
+org.gradle.parallel=true
 orcVersion=1.7.11


### PR DESCRIPTION
Speed up our CI pipeline:
* cache testcontainer images
* do not rebuild singlecluster image on every test run
* allow gradle parallel builds It was disabled for gradle 4.x in https://github.com/apache/cloudberry-pxf/commit/124115d1733fcea7c91514c98b2c58a1a0aaf81f