### PR TITLE
Align release artifact naming with Apache incubator conventions

### DIFF
--- a/package/cloudberry-pxf-release.sh
+++ b/package/cloudberry-pxf-release.sh
@@ -510,7 +510,7 @@ section "Staging release: $TAG"
 
   section "Creating Source Tarball"
 
-  TAR_NAME="apache-cloudberry-pxf-${TAG}-src.tar.gz"
+  TAR_NAME="apache-cloudberry-pxf-${VERSION_FILE}-incubating-src.tar.gz"
   TMP_DIR=$(mktemp -d)
   trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -518,8 +518,8 @@ section "Staging release: $TAG"
   export COPYFILE_DISABLE=1
   export COPY_EXTENDED_ATTRIBUTES_DISABLE=1
 
-  # Keep -rcN in the artifact filename for RC voting, but keep the extracted
-  # top-level directory name as the main version with -incubating (without -rcN).
+  # Use base version (without -rcN) for both tarball filename and extracted directory name.
+  # This allows direct svn mv to release repository after voting without renaming.
   git archive --format=tar --prefix="apache-cloudberry-pxf-${VERSION_FILE}-incubating/" "$TAG" | tar -x -C "$TMP_DIR"
 
   # Archive submodules if any


### PR DESCRIPTION
Update cloudberry-pxf-release.sh to generate artifact filenames without RC suffix (e.g., apache-cloudberry-pxf-2.1.0-incubating-src.tar.gz) while keeping RC identifier in directory names only.

Benefits:
- Simplifies promotion process after vote passes
- No need to rename files for checksums/signatures
- Consistent with best practices from other ASF Incubator projects
- Files are ready for final release from RC stage, can use `svn mv` to promote the RC artifacts to the final version.

Example structure:
  dev/incubator/cloudberry/2.1.0-incubating-rc1/ apache-cloudberry-pxf-2.1.0-incubating-src.tar.gz

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-pxf/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.