### PR TITLE
fix: fdw/external support filter pushdown for numeric columns with integer constants

### DIFF
--- a/external-table/src/pxffilters.c
+++ b/external-table/src/pxffilters.c
@@ -26,6 +26,7 @@
 
 #include "catalog/pg_operator.h"
 #include "optimizer/clauses.h"
+#include "optimizer/optimizer.h"
 #include "parser/parse_expr.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"

--- a/external-table/src/pxffilters.c
+++ b/external-table/src/pxffilters.c
@@ -775,6 +775,26 @@ opexpr_to_pxffilter(OpExpr *expr, PxfFilterDesc * filter)
 		}
 	}
 
+	/*
+	 * Try to evaluate constant expressions in operands.
+	 * This handles implicit type casts where PostgreSQL wraps a constant
+	 * in a FuncExpr (e.g., int4 -> numeric cast when comparing a numeric
+	 * column with an integer constant). Evaluating these gives us back a
+	 * plain Const node that we can serialize for filter pushdown.
+	 */
+	if (!IsA(leftop, Var) && !IsA(leftop, Const))
+	{
+		Node *simplified = eval_const_expressions(NULL, leftop);
+		if (IsA(simplified, Const))
+			leftop = simplified;
+	}
+	if (!IsA(rightop, Var) && !IsA(rightop, Const))
+	{
+		Node *simplified = eval_const_expressions(NULL, rightop);
+		if (IsA(simplified, Const))
+			rightop = simplified;
+	}
+
 	/* arguments must be VAR and CONST */
 	if (IsA(leftop, Var) && IsA(rightop, Const))
 	{

--- a/fdw/pxf_filter.c
+++ b/fdw/pxf_filter.c
@@ -852,6 +852,25 @@ OpExprToPxfFilter(OpExpr *expr, PxfFilterDesc *filter)
 		}
 	}
 
+	/*
+	 * Try to evaluate constant expressions in operands.
+	 * This handles implicit type casts where PostgreSQL wraps a constant
+	 * in a FuncExpr (e.g., int4 -> numeric cast when comparing a numeric
+	 * column with an integer constant). Evaluating these gives us back a
+	 * plain Const node that we can serialize for filter pushdown.
+	 */
+	if (!IsA(leftop, Var) && !IsA(leftop, Const))
+	{
+		Node *simplified = eval_const_expressions(NULL, leftop);
+		if (IsA(simplified, Const))
+			leftop = simplified;
+	}
+	if (!IsA(rightop, Var) && !IsA(rightop, Const))
+	{
+		Node *simplified = eval_const_expressions(NULL, rightop);
+		if (IsA(simplified, Const))
+			rightop = simplified;
+	}
 
 	/* arguments must be VAR and CONST */
 	if (IsA(leftop, Var) && IsA(rightop, Const))

--- a/fdw/pxf_filter.c
+++ b/fdw/pxf_filter.c
@@ -24,6 +24,7 @@
 
 #include "catalog/pg_operator.h"
 #include "optimizer/clauses.h"
+#include "optimizer/optimizer.h"
 #include "parser/parse_expr.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"

--- a/regression/expected/FDW_FilterPushDownTest.out
+++ b/regression/expected/FDW_FilterPushDownTest.out
@@ -486,9 +486,62 @@ SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
     |  0 | t  | 0.01 | AA | AA | a3o9
 (9 rows)
 
+-- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d1o2
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d1o2
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d1o2
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d1o2
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d1o2
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d1o2
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d1o2
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d1o2
+(8 rows)
+
+SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d2o3
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d2o3
+(2 rows)
+
+SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d5o4
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d5o4
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d5o4
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d5o4
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d5o4
+(5 rows)
+
+SELECT * FROM test_filter WHERE  c3 <> 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d5o6
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d5o6
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d5o6
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d5o6
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d5o6
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d5o6
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d5o6
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d5o6
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d5o6
+(9 rows)
+
+SELECT * FROM test_filter WHERE  c3 BETWEEN 1 AND 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |            filtervalue
+----+----+----+------+----+----+------------------------------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d1o4a3c1700s1d5o3l0
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d1o4a3c1700s1d5o3l0
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d1o4a3c1700s1d5o3l0
+(3 rows)
+
 -- test char predicates
 SELECT * FROM test_filter WHERE  d4 =  'BB' ORDER BY t0, a1;
- t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue   
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
 ----+----+----+------+----+----+----------------
  B  |    | f  | 1.11 | BB | BB | a4c1042s2dBBo5
 (1 row)
@@ -1222,9 +1275,62 @@ SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
     |  0 | t  | 0.01 | AA | AA | a3o9
 (9 rows)
 
+-- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d1o2
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d1o2
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d1o2
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d1o2
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d1o2
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d1o2
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d1o2
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d1o2
+(8 rows)
+
+SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d2o3
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d2o3
+(2 rows)
+
+SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d5o4
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d5o4
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d5o4
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d5o4
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d5o4
+(5 rows)
+
+SELECT * FROM test_filter WHERE  c3 <> 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d5o6
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d5o6
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d5o6
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d5o6
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d5o6
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d5o6
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d5o6
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d5o6
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d5o6
+(9 rows)
+
+SELECT * FROM test_filter WHERE  c3 BETWEEN 1 AND 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |            filtervalue
+----+----+----+------+----+----+------------------------------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d1o4a3c1700s1d5o3l0
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d1o4a3c1700s1d5o3l0
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d1o4a3c1700s1d5o3l0
+(3 rows)
+
 -- test char predicates
 SELECT * FROM test_filter WHERE  d4 =  'BB' ORDER BY t0, a1;
- t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue   
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
 ----+----+----+------+----+----+----------------
  B  |    | f  | 1.11 | BB | BB | a4c1042s2dBBo5
 (1 row)

--- a/regression/expected/FDW_FilterPushDownTest.out
+++ b/regression/expected/FDW_FilterPushDownTest.out
@@ -487,6 +487,20 @@ SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
 (9 rows)
 
 -- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 =  5 ORDER BY t0, a1;
+ t0 | a1 | b2 | c3 | d4 | e5 | filtervalue
+----+----+----+----+----+----+-------------
+(0 rows)
+
+SELECT * FROM test_filter WHERE  c3 <  5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d5o1
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d5o1
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d5o1
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d5o1
+(4 rows)
+
 SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
  t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
 ----+----+----+------+----+----+----------------
@@ -1276,6 +1290,20 @@ SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
 (9 rows)
 
 -- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 =  5 ORDER BY t0, a1;
+ t0 | a1 | b2 | c3 | d4 | e5 | filtervalue
+----+----+----+----+----+----+-------------
+(0 rows)
+
+SELECT * FROM test_filter WHERE  c3 <  5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d5o1
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d5o1
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d5o1
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d5o1
+(4 rows)
+
 SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
  t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
 ----+----+----+------+----+----+----------------

--- a/regression/expected/FilterPushDownTest.out
+++ b/regression/expected/FilterPushDownTest.out
@@ -483,9 +483,62 @@ SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
     |  0 | t  | 0.01 | AA | AA | a3o9
 (9 rows)
 
+-- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d1o2
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d1o2
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d1o2
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d1o2
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d1o2
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d1o2
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d1o2
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d1o2
+(8 rows)
+
+SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d2o3
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d2o3
+(2 rows)
+
+SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d5o4
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d5o4
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d5o4
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d5o4
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d5o4
+(5 rows)
+
+SELECT * FROM test_filter WHERE  c3 <> 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d5o6
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d5o6
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d5o6
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d5o6
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d5o6
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d5o6
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d5o6
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d5o6
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d5o6
+(9 rows)
+
+SELECT * FROM test_filter WHERE  c3 BETWEEN 1 AND 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |            filtervalue
+----+----+----+------+----+----+------------------------------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d1o4a3c1700s1d5o3l0
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d1o4a3c1700s1d5o3l0
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d1o4a3c1700s1d5o3l0
+(3 rows)
+
 -- test char predicates
 SELECT * FROM test_filter WHERE  d4 =  'BB' ORDER BY t0, a1;
- t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue   
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
 ----+----+----+------+----+----+----------------
  B  |    | f  | 1.11 | BB | BB | a4c1042s2dBBo5
 (1 row)
@@ -1219,9 +1272,62 @@ SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
     |  0 | t  | 0.01 | AA | AA | a3o8l2
 (9 rows)
 
+-- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d1o2
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d1o2
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d1o2
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d1o2
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d1o2
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d1o2
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d1o2
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d1o2
+(8 rows)
+
+SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d2o3
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d2o3
+(2 rows)
+
+SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d5o4
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d5o4
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d5o4
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d5o4
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d5o4
+(5 rows)
+
+SELECT * FROM test_filter WHERE  c3 <> 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d5o6
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d5o6
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d5o6
+ F  |  5 | f  | 5.51 | FF |    | a3c1700s1d5o6
+ G  |  6 | t  | 6.61 | GG | GG | a3c1700s1d5o6
+ H  |  7 | f  | 7.71 | HH | HH | a3c1700s1d5o6
+ I  |  8 | t  | 8.81 | II | II | a3c1700s1d5o6
+ J  |  9 | f  | 9.91 | JJ | JJ | a3c1700s1d5o6
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d5o6
+(9 rows)
+
+SELECT * FROM test_filter WHERE  c3 BETWEEN 1 AND 5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |            filtervalue
+----+----+----+------+----+----+------------------------------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d1o4a3c1700s1d5o3l0
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d1o4a3c1700s1d5o3l0
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d1o4a3c1700s1d5o3l0
+(3 rows)
+
 -- test char predicates
 SELECT * FROM test_filter WHERE  d4 =  'BB' ORDER BY t0, a1;
- t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue   
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
 ----+----+----+------+----+----+----------------
  B  |    | f  | 1.11 | BB | BB | a4c1042s2dBBo5
 (1 row)

--- a/regression/expected/FilterPushDownTest.out
+++ b/regression/expected/FilterPushDownTest.out
@@ -484,6 +484,20 @@ SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
 (9 rows)
 
 -- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 =  5 ORDER BY t0, a1;
+ t0 | a1 | b2 | c3 | d4 | e5 | filtervalue
+----+----+----+----+----+----+-------------
+(0 rows)
+
+SELECT * FROM test_filter WHERE  c3 <  5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d5o1
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d5o1
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d5o1
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d5o1
+(4 rows)
+
 SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
  t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
 ----+----+----+------+----+----+----------------
@@ -1273,6 +1287,20 @@ SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
 (9 rows)
 
 -- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 =  5 ORDER BY t0, a1;
+ t0 | a1 | b2 | c3 | d4 | e5 | filtervalue
+----+----+----+----+----+----+-------------
+(0 rows)
+
+SELECT * FROM test_filter WHERE  c3 <  5 ORDER BY t0, a1;
+ t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
+----+----+----+------+----+----+----------------
+ B  |    | f  | 1.11 | BB | BB | a3c1700s1d5o1
+ C  |  2 |    | 2.21 | CC | CC | a3c1700s1d5o1
+ E  |  4 | t  | 4.41 |    | EE | a3c1700s1d5o1
+    |  0 | t  | 0.01 | AA | AA | a3c1700s1d5o1
+(4 rows)
+
 SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
  t0 | a1 | b2 |  c3  | d4 | e5 |  filtervalue
 ----+----+----+------+----+----+----------------

--- a/regression/sql/FDW_FilterPushDownTest.sql
+++ b/regression/sql/FDW_FilterPushDownTest.sql
@@ -85,6 +85,8 @@ SELECT * FROM test_filter WHERE  c3 IS NULL ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
 
 -- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 =  5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <  5 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;
@@ -186,6 +188,8 @@ SELECT * FROM test_filter WHERE  c3 IS NULL ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
 
 -- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 =  5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <  5 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;

--- a/regression/sql/FDW_FilterPushDownTest.sql
+++ b/regression/sql/FDW_FilterPushDownTest.sql
@@ -84,6 +84,13 @@ SELECT * FROM test_filter WHERE  c3 NOT BETWEEN 1.11 AND 4.41 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NULL ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
 
+-- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <> 5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 BETWEEN 1 AND 5 ORDER BY t0, a1;
+
 -- test char predicates
 SELECT * FROM test_filter WHERE  d4 =  'BB' ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  d4 =  'BB ' ORDER BY t0, a1;
@@ -177,6 +184,13 @@ SELECT * FROM test_filter WHERE  c3 BETWEEN     1.11 AND 4.41 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 NOT BETWEEN 1.11 AND 4.41 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NULL ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
+
+-- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <> 5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 BETWEEN 1 AND 5 ORDER BY t0, a1;
 
 -- test char predicates
 SELECT * FROM test_filter WHERE  d4 =  'BB' ORDER BY t0, a1;

--- a/regression/sql/FilterPushDownTest.sql
+++ b/regression/sql/FilterPushDownTest.sql
@@ -81,6 +81,8 @@ SELECT * FROM test_filter WHERE  c3 IS NULL ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
 
 -- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 =  5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <  5 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;
@@ -180,6 +182,15 @@ SELECT * FROM test_filter WHERE  c3 BETWEEN     1.11 AND 4.41 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 NOT BETWEEN 1.11 AND 4.41 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NULL ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
+
+-- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 =  5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <  5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <> 5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 BETWEEN 1 AND 5 ORDER BY t0, a1;
 
 -- test char predicates
 SELECT * FROM test_filter WHERE  d4 =  'BB' ORDER BY t0, a1;

--- a/regression/sql/FilterPushDownTest.sql
+++ b/regression/sql/FilterPushDownTest.sql
@@ -80,6 +80,13 @@ SELECT * FROM test_filter WHERE  c3 NOT BETWEEN 1.11 AND 4.41 ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NULL ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  c3 IS NOT NULL ORDER BY t0, a1;
 
+-- test numeric predicates with integer constant (cross-type pushdown)
+SELECT * FROM test_filter WHERE  c3 >  1 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <= 2 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 >= 5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 <> 5 ORDER BY t0, a1;
+SELECT * FROM test_filter WHERE  c3 BETWEEN 1 AND 5 ORDER BY t0, a1;
+
 -- test char predicates
 SELECT * FROM test_filter WHERE  d4 =  'BB' ORDER BY t0, a1;
 SELECT * FROM test_filter WHERE  d4 =  'BB ' ORDER BY t0, a1;


### PR DESCRIPTION
<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->

<!--Remove this section if no corresponding issue.-->

---

## Change logs

When a numeric column is compared with an integer constant (e.g.,
    biz_dt = 20260331), PostgreSQL wraps the constant in an implicit
    type cast FuncExpr (int4 -> numeric). The filter extraction code
    only recognized plain Const nodes, causing these filters to be
    dropped and resulting in full table scans on the source.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-pxf/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.