### PR TITLE
cloudberry-pxf currently supports only cloudberry-2.x

### DIFF
--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -40,7 +40,7 @@ env:
   JAVA_HOME: "/usr/lib/jvm/java-11-openjdk"
   GO_VERSION: "1.25"
   GPHOME: "/usr/local/cloudberry-db"
-  CLOUDBERRY_VERSION: "PG14_ARCHIVE"
+  CLOUDBERRY_VERSION: "REL_2_STABLE"
   PXF_HOME: "/usr/local/pxf"
 
 jobs:

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -40,7 +40,7 @@ env:
   JAVA_HOME: "/usr/lib/jvm/java-11-openjdk"
   GO_VERSION: "1.25"
   GPHOME: "/usr/local/cloudberry-db"
-  CLOUDBERRY_VERSION: "main"
+  CLOUDBERRY_VERSION: "PG14_ARCHIVE"
   PXF_HOME: "/usr/local/pxf"
 
 jobs:
@@ -255,7 +255,9 @@ jobs:
   build-pxf-cbdb-testcontainer-image:
     name: Build Testcontainer Images (${{ matrix.distro }})
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         include:
           - distro: ubuntu

--- a/automation/src/main/resources/testcontainers/pxf-cbdb/Dockerfile
+++ b/automation/src/main/resources/testcontainers/pxf-cbdb/Dockerfile
@@ -70,7 +70,7 @@ RUN sudo mkdir -p /home/gpadmin/workspace && \
 
 # Clone Cloudberry source (parametrized via build args)
 ARG CLOUDBERRY_REPO=https://github.com/apache/cloudberry.git
-ARG CLOUDBERRY_BRANCH=PG14_ARCHIVE
+ARG CLOUDBERRY_BRANCH=REL_2_STABLE
 RUN git clone --depth 1 -b ${CLOUDBERRY_BRANCH} \
       ${CLOUDBERRY_REPO} /home/gpadmin/workspace/cloudberry
 

--- a/automation/src/main/resources/testcontainers/pxf-cbdb/Dockerfile
+++ b/automation/src/main/resources/testcontainers/pxf-cbdb/Dockerfile
@@ -20,7 +20,7 @@
 ARG BASE_IMAGE=apache/incubator-cloudberry:cbdb-build-ubuntu22.04-latest
 FROM ${BASE_IMAGE}
 
-# Install Java 8 & 11: auto-detect OS package manager
+# Install Java 11: auto-detect OS package manager
 RUN if command -v apt-get >/dev/null 2>&1; then \
       export DEBIAN_FRONTEND=noninteractive && \
       sudo apt-get update && \
@@ -29,7 +29,7 @@ RUN if command -v apt-get >/dev/null 2>&1; then \
         locales wget lsb-release openssh-server iproute2 sudo \
         openjdk-11-jdk-headless; \
     elif command -v dnf >/dev/null 2>&1; then \
-      sudo dnf install -y --allowerasing \
+      sudo dnf install -y --allowerasing --nobest \
         curl ca-certificates wget maven unzip openssh-server iproute sudo glibc-langpack-en glibc-locale-source \
         java-11-openjdk-devel && \
       sudo dnf clean all; \
@@ -70,7 +70,7 @@ RUN sudo mkdir -p /home/gpadmin/workspace && \
 
 # Clone Cloudberry source (parametrized via build args)
 ARG CLOUDBERRY_REPO=https://github.com/apache/cloudberry.git
-ARG CLOUDBERRY_BRANCH=main
+ARG CLOUDBERRY_BRANCH=PG14_ARCHIVE
 RUN git clone --depth 1 -b ${CLOUDBERRY_BRANCH} \
       ${CLOUDBERRY_REPO} /home/gpadmin/workspace/cloudberry
 

--- a/ci/docker/pxf-cbdb-dev/common/script/build_cloudberrry.sh
+++ b/ci/docker/pxf-cbdb-dev/common/script/build_cloudberrry.sh
@@ -24,7 +24,7 @@
 if command -v apt-get >/dev/null 2>&1; then
   sudo apt update && sudo apt install -y sudo git
 elif command -v dnf >/dev/null 2>&1; then
-  sudo dnf install -y sudo git
+  sudo dnf install -y --nobest sudo git
 fi
 
 # Required configuration
@@ -104,7 +104,7 @@ if command -v apt-get >/dev/null 2>&1; then
     rsync \
     libsnappy-dev
 elif command -v dnf >/dev/null 2>&1; then
-  sudo dnf install -y \
+  sudo dnf install -y --nobest \
     bison \
     bzip2 \
     cmake \

--- a/ci/docker/pxf-cbdb-dev/common/script/build_pxf.sh
+++ b/ci/docker/pxf-cbdb-dev/common/script/build_pxf.sh
@@ -38,7 +38,7 @@ if command -v apt-get >/dev/null 2>&1; then
   sudo apt update
   sudo apt install -y openjdk-11-jdk maven
 elif command -v dnf >/dev/null 2>&1; then
-  sudo dnf install -y java-11-openjdk-devel maven
+  sudo dnf install -y --nobest java-11-openjdk-devel maven
 fi
 
 cd /home/gpadmin/workspace/cloudberry-pxf

--- a/ci/docker/pxf-cbdb-dev/common/script/entrypoint.sh
+++ b/ci/docker/pxf-cbdb-dev/common/script/entrypoint.sh
@@ -154,8 +154,8 @@ install_build_deps() {
       libperl-dev make pkg-config protobuf-compiler python3-dev python3-pip python3-setuptools \
       rsync libsnappy-dev
   else
-    sudo dnf install -y sudo git
-    sudo dnf install -y --allowerasing bison bzip2 cmake curl flex gcc gcc-c++ iproute iputils \
+    sudo dnf install -y --nobest sudo git
+    sudo dnf install -y --nobest --allowerasing bison bzip2 cmake curl flex gcc gcc-c++ iproute iputils \
       glibc-langpack-en glibc-locale-source apr-devel bzip2-devel libcurl-devel libevent-devel \
       krb5-devel perl-IPC-Run openldap-devel pam-devel protobuf-devel readline-devel \
       openssl-devel libuv-devel lz4-devel libxml2-devel libyaml-devel \

--- a/ci/docker/pxf-cbdb-dev/common/script/entrypoint.sh
+++ b/ci/docker/pxf-cbdb-dev/common/script/entrypoint.sh
@@ -64,7 +64,7 @@ setup_locale_and_packages() {
     sudo locale-gen en_US.UTF-8 ru_RU.CP1251 ru_RU.UTF-8
     sudo update-locale LANG=en_US.UTF-8
   else
-    sudo dnf install -y wget maven unzip openssh-server iproute sudo \
+    sudo dnf install -y --nobest wget maven unzip openssh-server iproute sudo \
       java-11-openjdk-headless java-1.8.0-openjdk-headless \
       glibc-langpack-en glibc-locale-source
     sudo localedef -c -i en_US -f UTF-8 en_US.UTF-8 || true

--- a/ci/singlecluster/Dockerfile
+++ b/ci/singlecluster/Dockerfile
@@ -29,7 +29,7 @@ RUN if command -v apt-get >/dev/null 2>&1; then \
         openjdk-8-jdk-headless \
         openjdk-11-jdk-headless; \
     elif command -v dnf >/dev/null 2>&1; then \
-      sudo dnf install -y --allowerasing \
+      sudo dnf install -y --allowerasing --nobest \
         curl ca-certificates \
         java-1.8.0-openjdk-devel \
         java-11-openjdk-devel && \


### PR DESCRIPTION
1. Use cloudberry 2.x in CI
2. trying to workaround Rocky Linux issues:
   ```
    6.926   - package plexus-sec-dispatcher-2.0-28.module+el9.7.0+40002+8e3c44a9.noarch from appstream is filtered out by modular filtering
    6.926   - package plexus-sec-dispatcher-2.0-5.module+el9.7.0+40001+c4a4cc38.noarch from appstream is filtered out by modular filtering
   ```