### PR TITLE
Update gradle/actions/dependency-submission to v6.1.0

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: ./server
         run: make prepare-gradle-wrapper
       - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2  # v5.0.0
+        uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0
         with:
           build-root-directory: server
           artifact-retention-days: 5


### PR DESCRIPTION
v5.0.0 is no longer in the Apache infrastructure-actions allowlist (actions.yml). Bump to v6.1.0 which is already trusted.

See:
 - https://github.com/apache/infrastructure-actions/blob/2b6ec5f38ac73c7c5970f3b4f863e8d15bf12d7d/actions.yml#L424-L438

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #118 
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-pxf/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.