### PR TITLE
Bump log4j to 2.25.4

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -67,6 +67,8 @@ configure(javaProjects) {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 
+    ext['log4j2.version'] = '2.25.4'
+
     dependencyManagement {
         imports {
             mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
@@ -230,18 +232,7 @@ configure(javaProjects) {
                 entry("aws-java-sdk-s3")
             }
 
-            // currently imported BOM spring-boot-dependencies:2.5.12 includes log4j-bom:2.17.2 and
-            // importing a module log4j-spring-boot:2.17.2 results in its transitive Junit dependencies
-            // being put into compileClasspath so we have to exclude them here so they are not shipped with PXF
-            // this is fixed in log4j-spring-boot:2.19.0, which is used by spring-boot-dependencies:3.0.0+
-            // so when we upgrade to Spring Boot version 3.0.0+ we should remove this fix
-            // alternatively we can bump log4j-spring-boot to 2.19.0 and not use excludes
-            // dependency("org.apache.logging.log4j:log4j-spring-boot:2.19.0")
-            dependency("org.apache.logging.log4j:log4j-spring-boot:2.17.2") {
-                exclude("org.junit.vintage:junit-vintage-engine")
-                exclude("org.junit.jupiter:junit-jupiter-engine")
-                exclude("org.junit.jupiter:junit-jupiter-api")
-            }
+            dependency("org.apache.logging.log4j:log4j-spring-boot:2.25.4")
 
         }
     }

--- a/server/pxf-service/build.gradle
+++ b/server/pxf-service/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation("commons-codec:commons-codec")
     implementation("commons-collections:commons-collections")
     implementation("commons-lang:commons-lang")
+    implementation("commons-logging:commons-logging")
     implementation("org.springframework.boot:spring-boot-starter-log4j2")
     implementation("org.apache.logging.log4j:log4j-spring-boot")
     implementation('org.springframework.boot:spring-boot-starter-actuator')


### PR DESCRIPTION
## Summary

Bump log4j from 2.17.2 to 2.25.4. Closes CVE-2026-34480 (XmlLayout invalid XML output) and CVE-2026-34477 (SSL hostname verification bypass).

## Changes

`server/build.gradle`
- Add `ext['log4j2.version'] = '2.25.4'` so the version managed by the imported `spring-boot-dependencies` BOM (which pins log4j-bom 2.17.2) is overridden. A bomProperty override does not reach the nested log4j-bom, hence the explicit ext property.
- Replace the `log4j-spring-boot:2.17.2` pin (and its junit excludes) with `log4j-spring-boot:2.25.4`. The excludes were a workaround for junit leaking into compileClasspath in 2.17.2; this was fixed upstream in 2.19.0, so at 2.25.4 they are dead code (the old comment said to remove them on upgrade).

`server/pxf-service/build.gradle`
- Add an explicit commons-logging dependency. log4j-spring-boot 2.25.4 no longer pulls it transitively, so without this it drops out of the jar.

## Verification

- **Build and tests are green.** `./gradlew :pxf-api:test :pxf-service:test`on JDK 8 — BUILD SUCCESSFUL, 679 tests, 678 passed, 0 failed, 1 skipped.`api/core/jul/spring-boot`, with no junit leaked into the jar and commons-logging-1.1.3 present.
- **Logging is healthy at runtime.** pxf-service.log is written with the expected Log4j2 layout, with zero `StatusLogger` init errors and no log4j config errors;