### PR TITLE
Explicit dependencies in pxf-hdfs

### DIFF
--- a/server/pxf-hdfs/build.gradle
+++ b/server/pxf-hdfs/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     testCompileOnly("org.apache.hadoop:hadoop-annotations")
 
     testImplementation("io.airlift:aircompressor")       // for HcfsTypeTest for testing write URI with LzopCodec
-    testImplementation("org.apache.parquet:parquet-pig") // for parquet tests
+    testImplementation("org.apache.parquet:parquet-pig")             { transitive = false } // for parquet tests
     testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 

--- a/server/pxf-hdfs/build.gradle
+++ b/server/pxf-hdfs/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation("org.apache.commons:commons-compress")            { transitive = false }
     implementation("org.tukaani:xz")                                 { transitive = false }
     implementation("com.github.luben:zstd-jni")                      { transitive = false }
+    implementation("org.xerial.snappy:snappy-java")                  { transitive = false }
 
 
     // Hadoop 2.10.1 uses log4j:1.2.17, but since we are using slf4j

--- a/server/pxf-hdfs/build.gradle
+++ b/server/pxf-hdfs/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation("org.tukaani:xz")                                 { transitive = false }
     implementation("com.github.luben:zstd-jni")                      { transitive = false }
     implementation("org.xerial.snappy:snappy-java")                  { transitive = false }
+    implementation("io.airlift:aircompressor")                       { transitive = false }
 
 
     // Hadoop 2.10.1 uses log4j:1.2.17, but since we are using slf4j
@@ -99,7 +100,6 @@ dependencies {
 
     testCompileOnly("org.apache.hadoop:hadoop-annotations")
 
-    testImplementation("io.airlift:aircompressor")       // for HcfsTypeTest for testing write URI with LzopCodec
     testImplementation("org.apache.parquet:parquet-pig")             { transitive = false } // for parquet tests
     testImplementation('org.springframework.boot:spring-boot-starter-test')
 }


### PR DESCRIPTION
I just found out that in our fork (legacy-pxf) we have broken dependences. I was curious why we don't seen an issue in tests. And, I realised that `parquet-pig` transitively pulls couple compressors to testRuntimeClasspath and hides the fact that pxf-hdfs doesn't have snappy (and zstd in my fork) as direct runtime dependency.

```
+--- org.apache.parquet:parquet-pig -> 1.15.2
    +--- org.apache.parquet:parquet-hadoop -> 1.15.2
    |    +--- org.apache.parquet:parquet-column:1.15.2 (*)
    |    +--- org.apache.parquet:parquet-format-structures:1.15.2 (*)
    |    +--- org.apache.parquet:parquet-common:1.15.2 (*)
    |    +--- org.apache.parquet:parquet-jackson:1.15.2
    |    +--- org.xerial.snappy:snappy-java:1.1.10.7
    |    +--- io.airlift:aircompressor:2.0.2
    |    +--- commons-pool:commons-pool:1.6
    |    +--- com.github.luben:zstd-jni:1.5.6-6 -> 1.5.7-6
    |    \--- org.slf4j:slf4j-api:1.7.33 -> 1.7.36
```

So, this PR removes transitive test-dependencies and explicitly adds runtime dependencies