### PR TITLE
Testcontainers: run PxfExtensionTest in testcontainers

### DIFF
--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -656,8 +656,8 @@ jobs:
         tc_group:
           - 'pxf-jdbc'
           - 'pxf-s3'
-          - 'pxfExtension'
-          - 'pxfFdwExtension'
+          - 'pxf-extension'
+          - 'pxf-fdw-extension'
         use_fdw:
           - 'false'
           - 'true'
@@ -665,9 +665,9 @@ jobs:
           - 'ubuntu'
           - 'rocky9'
         exclude:
-          - tc_group: 'pxfExtension'
+          - tc_group: 'pxf-extension'
             use_fdw: 'true'
-          - tc_group: 'pxfFdwExtension'
+          - tc_group: 'pxf-fdw-extension'
             use_fdw: 'false'
     steps:
       - name: Checkout PXF source

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -334,7 +334,6 @@ jobs:
           - gpdb
           - gpdb_fdw
           - load
-          - pxf_extension
     steps:
     - name: Free disk space
       run: |
@@ -504,7 +503,6 @@ jobs:
           - gpdb
           - gpdb_fdw
           - load
-          - pxf_extension
     steps:
     - name: Free disk space
       run: |
@@ -658,12 +656,19 @@ jobs:
         tc_group:
           - 'pxf-jdbc'
           - 'pxf-s3'
+          - 'pxfExtension'
+          - 'pxfFdwExtension'
         use_fdw:
           - 'false'
           - 'true'
         distro:
           - 'ubuntu'
           - 'rocky9'
+        exclude:
+          - tc_group: 'pxfExtension'
+            use_fdw: 'true'
+          - tc_group: 'pxfFdwExtension'
+            use_fdw: 'false'
     steps:
       - name: Checkout PXF source
         uses: actions/checkout@v4

--- a/automation/sqlrepo/features/extension_tests/create_extension/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/create_extension/expected/query01.ans
@@ -40,33 +40,3 @@ ORDER BY 1;
  pxfwritable_export  | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import  | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (6 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)

--- a/automation/sqlrepo/features/extension_tests/create_extension/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/create_extension/sql/query01.sql
@@ -22,7 +22,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;

--- a/automation/sqlrepo/features/extension_tests/create_extension_rpm/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/create_extension_rpm/expected/query01.ans
@@ -39,22 +39,3 @@ ORDER BY 1;
  pxfwritable_export | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (5 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;
-ERROR:  formatter function "pxfdelimited_import" of type readable was not found
-HINT:  Create it with CREATE FUNCTION.

--- a/automation/sqlrepo/features/extension_tests/create_extension_rpm/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/create_extension_rpm/sql/query01.sql
@@ -22,7 +22,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;

--- a/automation/sqlrepo/features/extension_tests/downgrade/step_1_create_extension/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/downgrade/step_1_create_extension/expected/query01.ans
@@ -41,33 +41,3 @@ ORDER BY 1;
  pxfwritable_export  | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import  | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (6 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)

--- a/automation/sqlrepo/features/extension_tests/downgrade/step_1_create_extension/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/downgrade/step_1_create_extension/sql/query01.sql
@@ -22,7 +22,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;

--- a/automation/sqlrepo/features/extension_tests/downgrade/step_2_after_alter_extension_downgrade/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/downgrade/step_2_after_alter_extension_downgrade/expected/query01.ans
@@ -46,22 +46,3 @@ ORDER BY 1;
  pxfwritable_export | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (5 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;
-ERROR:  formatter function "pxfdelimited_import" of type readable was not found
-HINT:  Create it with CREATE FUNCTION.

--- a/automation/sqlrepo/features/extension_tests/downgrade/step_2_after_alter_extension_downgrade/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/downgrade/step_2_after_alter_extension_downgrade/sql/query01.sql
@@ -28,7 +28,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;

--- a/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_1_check_extension/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_1_check_extension/expected/query01.ans
@@ -41,33 +41,3 @@ ORDER BY 1;
  pxfwritable_export  | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import  | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (6 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)

--- a/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_1_check_extension/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_1_check_extension/sql/query01.sql
@@ -22,7 +22,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;

--- a/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_2_after_alter_extension_downgrade/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_2_after_alter_extension_downgrade/expected/query01.ans
@@ -46,22 +46,3 @@ ORDER BY 1;
  pxfwritable_export | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (5 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;
-ERROR:  formatter function "pxfdelimited_import" of type readable was not found
-HINT:  Create it with CREATE FUNCTION.

--- a/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_2_after_alter_extension_downgrade/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_2_after_alter_extension_downgrade/sql/query01.sql
@@ -28,7 +28,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;

--- a/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_3_after_alter_extension_upgrade/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_3_after_alter_extension_upgrade/expected/query01.ans
@@ -41,33 +41,3 @@ ORDER BY 1;
  pxfwritable_export  | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import  | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (6 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)

--- a/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_3_after_alter_extension_upgrade/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/downgrade_then_upgrade/step_3_after_alter_extension_upgrade/sql/query01.sql
@@ -22,7 +22,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;

--- a/automation/sqlrepo/features/extension_tests/explicit_upgrade/step_1_create_extension_with_older_pxf_version/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/explicit_upgrade/step_1_create_extension_with_older_pxf_version/expected/query01.ans
@@ -40,18 +40,3 @@ ORDER BY 1;
  pxfwritable_export | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (5 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)

--- a/automation/sqlrepo/features/extension_tests/explicit_upgrade/step_1_create_extension_with_older_pxf_version/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/explicit_upgrade/step_1_create_extension_with_older_pxf_version/sql/query01.sql
@@ -22,5 +22,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;

--- a/automation/sqlrepo/features/extension_tests/explicit_upgrade/step_2_after_alter_extension/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/explicit_upgrade/step_2_after_alter_extension/expected/query01.ans
@@ -41,33 +41,3 @@ ORDER BY 1;
  pxfwritable_export  | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import  | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (6 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)

--- a/automation/sqlrepo/features/extension_tests/explicit_upgrade/step_2_after_alter_extension/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/explicit_upgrade/step_2_after_alter_extension/sql/query01.sql
@@ -22,7 +22,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;

--- a/automation/sqlrepo/features/extension_tests/upgrade/step_1_create_extension_with_older_pxf_version/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/upgrade/step_1_create_extension_with_older_pxf_version/expected/query01.ans
@@ -41,18 +41,3 @@ ORDER BY 1;
  pxfwritable_export | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (5 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)

--- a/automation/sqlrepo/features/extension_tests/upgrade/step_1_create_extension_with_older_pxf_version/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/upgrade/step_1_create_extension_with_older_pxf_version/sql/query01.sql
@@ -22,5 +22,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;

--- a/automation/sqlrepo/features/extension_tests/upgrade/step_2_after_alter_extension/expected/query01.ans
+++ b/automation/sqlrepo/features/extension_tests/upgrade/step_2_after_alter_extension/expected/query01.ans
@@ -41,33 +41,3 @@ ORDER BY 1;
  pxfwritable_export  | gpdbwritableformatter_export | $PXF_HOME/gpextable/pxf
  pxfwritable_import  | gpdbwritableformatter_import | $PXF_HOME/gpextable/pxf
 (6 rows)
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;
-  name  | num | dub |    longnum    | bool
---------+-----+-----+---------------+------
- row_1  |   1 |   1 |  100000000000 | f
- row_2  |   2 |   2 |  200000000000 | t
- row_3  |   3 |   3 |  300000000000 | f
- row_4  |   4 |   4 |  400000000000 | t
- row_5  |   5 |   5 |  500000000000 | f
- row_6  |   6 |   6 |  600000000000 | t
- row_7  |   7 |   7 |  700000000000 | f
- row_8  |   8 |   8 |  800000000000 | t
- row_9  |   9 |   9 |  900000000000 | f
- row_10 |  10 |  10 | 1000000000000 | t
-(10 rows)

--- a/automation/sqlrepo/features/extension_tests/upgrade/step_2_after_alter_extension/sql/query01.sql
+++ b/automation/sqlrepo/features/extension_tests/upgrade/step_2_after_alter_extension/sql/query01.sql
@@ -22,7 +22,3 @@ FROM pg_catalog.pg_extension AS e
     INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
 WHERE d.deptype = 'e' AND e.extname = 'pxf'
 ORDER BY 1;
-
-SELECT * FROM pxf_upgrade_test ORDER BY num;
-
-SELECT * FROM pxf_upgrade_test_multibyte ORDER BY num;

--- a/automation/src/main/java/org/apache/cloudberry/pxf/automation/applications/CloudberryApplication.java
+++ b/automation/src/main/java/org/apache/cloudberry/pxf/automation/applications/CloudberryApplication.java
@@ -210,6 +210,10 @@ public class CloudberryApplication implements AutoCloseable {
         }
     }
 
+    public void dropDatabase(String dbName) throws Exception {
+        runQuery("DROP DATABASE IF EXISTS " + dbName, true);
+    }
+
     public void createExtension(String extensionName, boolean ignoreFail) throws Exception {
         runQuery("CREATE EXTENSION IF NOT EXISTS " + extensionName, ignoreFail);
     }

--- a/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/extension/PxfExtensionTest.java
+++ b/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/extension/PxfExtensionTest.java
@@ -1,142 +1,103 @@
 package org.apache.cloudberry.pxf.automation.features.extension;
 
-import org.apache.cloudberry.pxf.automation.BaseFunctionality;
-import org.apache.cloudberry.pxf.automation.structures.tables.basic.Table;
-import org.apache.cloudberry.pxf.automation.structures.tables.pxf.ReadableExternalTable;
-import org.apache.cloudberry.pxf.automation.structures.tables.utils.TableFactory;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.cloudberry.pxf.automation.AbstractTestcontainersTest;
+import org.apache.cloudberry.pxf.automation.applications.CloudberryApplication;
 import org.testng.annotations.Test;
 
-public class PxfExtensionTest extends BaseFunctionality {
+public class PxfExtensionTest extends AbstractTestcontainersTest {
 
-    public static final String[] FIELDS = {
-            "name    text",
-            "num     integer",
-            "dub     double precision",
-            "longNum bigint",
-            "bool    boolean"
-    };
-
-    private ReadableExternalTable externalTable;
-    private String location;
-    private String location_multi;
+    private CloudberryApplication extensionDb;
 
     @Override
-    public void beforeClass() throws Exception {
-        super.beforeClass();
-        gpdb.dropDataBase("pxfautomation_extension", true, true);
-        gpdb.createDataBase("pxfautomation_extension", false);
-        gpdb.setDb("pxfautomation_extension");
-        gpdb.connectToDataBase("pxfautomation_extension");
+    protected void beforeClass() throws Exception {
+        // pxf_regress scripts run "\c pxfautomation_extension", so the database must exist in the container.
+        cloudberry.dropDatabase("pxfautomation_extension");
+        cloudberry.createDatabase("pxfautomation_extension");
 
-        Table smallData = getSmallData("", 10);
-
-        location = hdfs.getWorkingDirectory() + "/upgrade-test-data.txt";
-        hdfs.writeTableToFile(location, smallData, ",");
-
-        location_multi = hdfs.getWorkingDirectory() + "/upgrade-test-data_multibyte.txt";
-        hdfs.writeTableToFile(location_multi, smallData, "停");
+        extensionDb = new CloudberryApplication(container, "pxfautomation_extension");
+        extensionDb.connect();
     }
 
     @Override
-    public void afterClass() throws Exception {
-        gpdb.connectToDataBase("pxfautomation");
-        gpdb.dropDataBase("pxfautomation_extension", true, true);
-        super.afterClass();
-    }
-
-    @Override
-    public void beforeMethod() throws Exception {
-        gpdb.setDb("pxfautomation_extension");
-        gpdb.connectToDataBase("pxfautomation_extension");
-        gpdb.runQuery("DROP EXTENSION IF EXISTS pxf CASCADE", true, false);
-    }
-
-    @Test(groups = {"gpdb", "pxfExtensionVersion2_1"})
-    public void testPxfCreateExtension() throws Exception {
-        gpdb.runQuery("CREATE EXTENSION pxf");
-        // create a regular external table
-        createReadablePxfTable("default", location, false);
-        // create an external table with the multibyte formatter
-        createReadablePxfTable("default", location_multi, true);
-        runSqlTest("features/extension_tests/create_extension");
-    }
-
-    @Test(groups = {"pxfExtensionVersion2"})
-    public void testPxfCreateExtensionOldRPM() throws Exception {
-        gpdb.runQuery("CREATE EXTENSION pxf");
-        // create a regular external table
-        createReadablePxfTable("default", location, false);
-        // create an external table with the multibyte formatter
-        createReadablePxfTable("default", location_multi, true);
-        runSqlTest("features/extension_tests/create_extension_rpm");
-    }
-
-    @Test(groups = {"gpdb", "pxfExtensionVersion2_1"})
-    public void testPxfUpgrade() throws Exception {
-        gpdb.runQuery("CREATE EXTENSION pxf VERSION '2.0'");
-        createReadablePxfTable("default", location, false);
-        runSqlTest("features/extension_tests/upgrade/step_1_create_extension_with_older_pxf_version");
-
-        // create an external table with the multibyte formatter
-        createReadablePxfTable("default", location_multi, true);
-        gpdb.runQuery("ALTER EXTENSION pxf UPDATE");
-        runSqlTest("features/extension_tests/upgrade/step_2_after_alter_extension");
-    }
-
-    @Test(groups = {"gpdb", "pxfExtensionVersion2_1"})
-    public void testPxfExplicitUpgrade() throws Exception {
-        gpdb.runQuery("CREATE EXTENSION pxf VERSION '2.0'");
-        createReadablePxfTable("default", location, false);
-        runSqlTest("features/extension_tests/explicit_upgrade/step_1_create_extension_with_older_pxf_version");
-
-        // create an external table with the multibyte formatter
-        createReadablePxfTable("default", location_multi, true);
-        gpdb.runQuery("ALTER EXTENSION pxf UPDATE TO '2.1'");
-        runSqlTest("features/extension_tests/explicit_upgrade/step_2_after_alter_extension");
-    }
-
-    @Test(groups = {"gpdb", "pxfExtensionVersion2_1"})
-    public void testPxfDowngrade() throws Exception {
-        gpdb.runQuery("CREATE EXTENSION pxf");
-
-        createReadablePxfTable("default", location, false);
-        // create an external table with the multibyte formatter
-        createReadablePxfTable("default", location_multi, true);
-        runSqlTest("features/extension_tests/downgrade/step_1_create_extension");
-
-        gpdb.runQuery("ALTER EXTENSION pxf UPDATE TO '2.0'");
-        runSqlTest("features/extension_tests/downgrade/step_2_after_alter_extension_downgrade");
-    }
-
-    @Test(groups = {"gpdb", "pxfExtensionVersion2_1"})
-    public void testPxfDowngradeThenUpgradeAgain() throws Exception {
-        gpdb.runQuery("CREATE EXTENSION pxf");
-
-        createReadablePxfTable("default", location, false);
-        // create an external table with the multibyte formatter
-        createReadablePxfTable("default", location_multi, true);
-        runSqlTest("features/extension_tests/downgrade_then_upgrade/step_1_check_extension");
-
-        gpdb.runQuery("ALTER EXTENSION pxf UPDATE TO '2.0'");
-        runSqlTest("features/extension_tests/downgrade_then_upgrade/step_2_after_alter_extension_downgrade");
-
-        gpdb.runQuery("ALTER EXTENSION pxf UPDATE TO '2.1'");
-        runSqlTest("features/extension_tests/downgrade_then_upgrade/step_3_after_alter_extension_upgrade");
-    }
-
-    private void createReadablePxfTable(String serverName, String location, boolean multi) throws Exception {
-        if (multi) {
-            externalTable = TableFactory.getPxfReadableTextTable("pxf_upgrade_test_multibyte", FIELDS, location, null);
-            externalTable.setFormat("CUSTOM");
-            externalTable.setFormatter("pxfdelimited_import");
-            externalTable.addFormatterOption("delimiter='停'");
-        } else {
-            externalTable = TableFactory.getPxfReadableTextTable("pxf_upgrade_test", FIELDS, location, ",");
+    protected void afterClass() throws Exception {
+        if (extensionDb != null) {
+            extensionDb.close();
         }
-        externalTable.setHost(pxfHost);
-        externalTable.setPort(pxfPort);
-        externalTable.setServer("SERVER=" + serverName);
-        gpdb.createTableAndVerify(externalTable);
+        cloudberry.dropDatabase("pxfautomation_extension");
     }
 
+    @Override
+    protected void beforeMethod() throws Exception {
+        extensionDb.runQuery("DROP EXTENSION IF EXISTS pxf CASCADE", true);
+    }
+
+    @Test(groups = {"testcontainers", "pxfExtension"})
+    public void testPxfCreateExtension() throws Exception {
+        extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.1'");
+        regress.runSqlTest("features/extension_tests/create_extension");
+    }
+
+    @Test(groups = {"testcontainers", "pxfExtension"})
+    public void testPxfCreateExtensionOldRPM() throws Exception {
+        extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.0'");
+        regress.runSqlTest("features/extension_tests/create_extension_rpm");
+    }
+
+    @Test(groups = {"testcontainers", "pxfExtension"})
+    public void testPxfUpgrade() throws Exception {
+        extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.0'");
+        regress.runSqlTest("features/extension_tests/upgrade/step_1_create_extension_with_older_pxf_version");
+
+        extensionDb.runQuery("ALTER EXTENSION pxf UPDATE TO '2.1'");
+        regress.runSqlTest("features/extension_tests/upgrade/step_2_after_alter_extension");
+    }
+
+    @Test(groups = {"testcontainers", "pxfExtension"})
+    public void testPxfExplicitUpgrade() throws Exception {
+        extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.0'");
+        regress.runSqlTest("features/extension_tests/explicit_upgrade/step_1_create_extension_with_older_pxf_version");
+
+        extensionDb.runQuery("ALTER EXTENSION pxf UPDATE TO '2.1'");
+        regress.runSqlTest("features/extension_tests/explicit_upgrade/step_2_after_alter_extension");
+    }
+
+    @Test(groups = {"testcontainers", "pxfExtension"})
+    public void testPxfDowngrade() throws Exception {
+        extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.1'");
+        regress.runSqlTest("features/extension_tests/downgrade/step_1_create_extension");
+
+        extensionDb.runQuery("ALTER EXTENSION pxf UPDATE TO '2.0'");
+        regress.runSqlTest("features/extension_tests/downgrade/step_2_after_alter_extension_downgrade");
+    }
+
+    @Test(groups = {"testcontainers", "pxfExtension"})
+    public void testPxfDowngradeThenUpgradeAgain() throws Exception {
+        extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.1'");
+        regress.runSqlTest("features/extension_tests/downgrade_then_upgrade/step_1_check_extension");
+
+        extensionDb.runQuery("ALTER EXTENSION pxf UPDATE TO '2.0'");
+        regress.runSqlTest("features/extension_tests/downgrade_then_upgrade/step_2_after_alter_extension_downgrade");
+
+        extensionDb.runQuery("ALTER EXTENSION pxf UPDATE TO '2.1'");
+        regress.runSqlTest("features/extension_tests/downgrade_then_upgrade/step_3_after_alter_extension_upgrade");
+    }
 }

--- a/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/extension/PxfExtensionTest.java
+++ b/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/extension/PxfExtensionTest.java
@@ -50,19 +50,19 @@ public class PxfExtensionTest extends AbstractTestcontainersTest {
         extensionDb.runQuery("DROP EXTENSION IF EXISTS pxf CASCADE", true);
     }
 
-    @Test(groups = {"testcontainers", "pxfExtension"})
+    @Test(groups = {"testcontainers", "pxf-extension"})
     public void testPxfCreateExtension() throws Exception {
         extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.1'");
         regress.runSqlTest("features/extension_tests/create_extension");
     }
 
-    @Test(groups = {"testcontainers", "pxfExtension"})
+    @Test(groups = {"testcontainers", "pxf-extension"})
     public void testPxfCreateExtensionOldRPM() throws Exception {
         extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.0'");
         regress.runSqlTest("features/extension_tests/create_extension_rpm");
     }
 
-    @Test(groups = {"testcontainers", "pxfExtension"})
+    @Test(groups = {"testcontainers", "pxf-extension"})
     public void testPxfUpgrade() throws Exception {
         extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.0'");
         regress.runSqlTest("features/extension_tests/upgrade/step_1_create_extension_with_older_pxf_version");
@@ -71,7 +71,7 @@ public class PxfExtensionTest extends AbstractTestcontainersTest {
         regress.runSqlTest("features/extension_tests/upgrade/step_2_after_alter_extension");
     }
 
-    @Test(groups = {"testcontainers", "pxfExtension"})
+    @Test(groups = {"testcontainers", "pxf-extension"})
     public void testPxfExplicitUpgrade() throws Exception {
         extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.0'");
         regress.runSqlTest("features/extension_tests/explicit_upgrade/step_1_create_extension_with_older_pxf_version");
@@ -80,7 +80,7 @@ public class PxfExtensionTest extends AbstractTestcontainersTest {
         regress.runSqlTest("features/extension_tests/explicit_upgrade/step_2_after_alter_extension");
     }
 
-    @Test(groups = {"testcontainers", "pxfExtension"})
+    @Test(groups = {"testcontainers", "pxf-extension"})
     public void testPxfDowngrade() throws Exception {
         extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.1'");
         regress.runSqlTest("features/extension_tests/downgrade/step_1_create_extension");
@@ -89,7 +89,7 @@ public class PxfExtensionTest extends AbstractTestcontainersTest {
         regress.runSqlTest("features/extension_tests/downgrade/step_2_after_alter_extension_downgrade");
     }
 
-    @Test(groups = {"testcontainers", "pxfExtension"})
+    @Test(groups = {"testcontainers", "pxf-extension"})
     public void testPxfDowngradeThenUpgradeAgain() throws Exception {
         extensionDb.runQuery("CREATE EXTENSION pxf VERSION '2.1'");
         regress.runSqlTest("features/extension_tests/downgrade_then_upgrade/step_1_check_extension");

--- a/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/extension/PxfFdwExtensionTest.java
+++ b/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/extension/PxfFdwExtensionTest.java
@@ -1,64 +1,85 @@
 package org.apache.cloudberry.pxf.automation.features.extension;
 
-import org.apache.cloudberry.pxf.automation.BaseFunctionality;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.cloudberry.pxf.automation.AbstractTestcontainersTest;
+import org.apache.cloudberry.pxf.automation.applications.CloudberryApplication;
 import org.testng.annotations.Test;
 
-public class PxfFdwExtensionTest extends BaseFunctionality {
+public class PxfFdwExtensionTest extends AbstractTestcontainersTest {
+
+    private CloudberryApplication extensionDb;
 
     @Override
-    public void beforeClass() throws Exception {
-        super.beforeClass();
-        gpdb.dropDataBase("pxfautomation_extension", true, true);
-        gpdb.createDataBase("pxfautomation_extension", false);
-        gpdb.setDb("pxfautomation_extension");
-        gpdb.connectToDataBase("pxfautomation_extension");
+    protected void beforeClass() throws Exception {
+        // pxf_regress scripts run "\c pxfautomation_extension", so the database must exist in the container.
+        cloudberry.dropDatabase("pxfautomation_extension");
+        cloudberry.createDatabase("pxfautomation_extension");
+
+        extensionDb = new CloudberryApplication(container, "pxfautomation_extension");
+        extensionDb.connect();
     }
 
     @Override
-    public void afterClass() throws Exception {
-        gpdb.connectToDataBase("pxfautomation");
-        gpdb.dropDataBase("pxfautomation_extension", true, true);
-        super.afterClass();
+    protected void afterClass() throws Exception {
+        if (extensionDb != null) {
+            extensionDb.close();
+        }
+        cloudberry.dropDatabase("pxfautomation_extension");
     }
 
     @Override
-    public void beforeMethod() throws Exception {
-        gpdb.setDb("pxfautomation_extension");
-        gpdb.connectToDataBase("pxfautomation_extension");
-        gpdb.runQuery("DROP EXTENSION IF EXISTS pxf_fdw CASCADE", true, false);
+    protected void beforeMethod() throws Exception {
+        extensionDb.runQuery("DROP EXTENSION IF EXISTS pxf_fdw CASCADE", true);
     }
 
-    @Test(groups = {"pxfFdwExtensionVersion2"})
+    @Test(groups = {"testcontainers", "pxfFdwExtension"})
     public void testPxfCreateExtension() throws Exception {
-        gpdb.runQuery("CREATE EXTENSION pxf_fdw");
-        runSqlTest("features/fdw_extension_tests/create_extension");
+        extensionDb.runQuery("CREATE EXTENSION pxf_fdw VERSION '2.0'");
+        regress.runSqlTest("features/fdw_extension_tests/create_extension");
     }
 
-    @Test(groups = {"pxfFdwExtensionVersion1"})
+    @Test(groups = {"testcontainers", "pxfFdwExtension"})
     public void testPxfCreateExtensionOldRPM() throws Exception {
-        gpdb.runQuery("CREATE EXTENSION pxf_fdw");
-        runSqlTest("features/fdw_extension_tests/create_extension_rpm");
+        extensionDb.runQuery("CREATE EXTENSION pxf_fdw VERSION '1.0'");
+        regress.runSqlTest("features/fdw_extension_tests/create_extension_rpm");
     }
 
-    @Test(groups = {"pxfFdwExtensionVersion2"})
+    @Test(groups = {"testcontainers", "pxfFdwExtension"})
     public void testPxfUpgrade() throws Exception {
-        gpdb.runQuery("CREATE EXTENSION pxf_fdw VERSION '1.0'");
-        runSqlTest("features/fdw_extension_tests/upgrade/step_1_create_extension_with_older_pxf_version");
+        extensionDb.runQuery("CREATE EXTENSION pxf_fdw VERSION '1.0'");
+        regress.runSqlTest("features/fdw_extension_tests/upgrade/step_1_create_extension_with_older_pxf_version");
 
-        gpdb.runQuery("ALTER EXTENSION pxf_fdw UPDATE");
-        runSqlTest("features/fdw_extension_tests/upgrade/step_2_after_alter_extension");
+        extensionDb.runQuery("ALTER EXTENSION pxf_fdw UPDATE TO '2.0'");
+        regress.runSqlTest("features/fdw_extension_tests/upgrade/step_2_after_alter_extension");
     }
 
-    @Test(groups = {"pxfFdwExtensionVersion2"})
+    @Test(groups = {"testcontainers", "pxfFdwExtension"})
     public void testPxfDowngradeThenUpgradeAgain() throws Exception {
-        gpdb.runQuery("CREATE EXTENSION pxf_fdw");
-        runSqlTest("features/fdw_extension_tests/downgrade_then_upgrade/step_1_check_extension");
+        extensionDb.runQuery("CREATE EXTENSION pxf_fdw VERSION '2.0'");
+        regress.runSqlTest("features/fdw_extension_tests/downgrade_then_upgrade/step_1_check_extension");
 
-        gpdb.runQuery("ALTER EXTENSION pxf_fdw UPDATE TO '1.0'");
-        runSqlTest("features/fdw_extension_tests/downgrade_then_upgrade/step_2_after_alter_extension_downgrade");
+        extensionDb.runQuery("ALTER EXTENSION pxf_fdw UPDATE TO '1.0'");
+        regress.runSqlTest("features/fdw_extension_tests/downgrade_then_upgrade/step_2_after_alter_extension_downgrade");
 
-        gpdb.runQuery("ALTER EXTENSION pxf_fdw UPDATE TO '2.0'");
-        runSqlTest("features/fdw_extension_tests/downgrade_then_upgrade/step_3_after_alter_extension_upgrade");
+        extensionDb.runQuery("ALTER EXTENSION pxf_fdw UPDATE TO '2.0'");
+        regress.runSqlTest("features/fdw_extension_tests/downgrade_then_upgrade/step_3_after_alter_extension_upgrade");
     }
-
 }

--- a/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/extension/PxfFdwExtensionTest.java
+++ b/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/extension/PxfFdwExtensionTest.java
@@ -50,19 +50,19 @@ public class PxfFdwExtensionTest extends AbstractTestcontainersTest {
         extensionDb.runQuery("DROP EXTENSION IF EXISTS pxf_fdw CASCADE", true);
     }
 
-    @Test(groups = {"testcontainers", "pxfFdwExtension"})
+    @Test(groups = {"testcontainers", "pxf-fdw-extension"})
     public void testPxfCreateExtension() throws Exception {
         extensionDb.runQuery("CREATE EXTENSION pxf_fdw VERSION '2.0'");
         regress.runSqlTest("features/fdw_extension_tests/create_extension");
     }
 
-    @Test(groups = {"testcontainers", "pxfFdwExtension"})
+    @Test(groups = {"testcontainers", "pxf-fdw-extension"})
     public void testPxfCreateExtensionOldRPM() throws Exception {
         extensionDb.runQuery("CREATE EXTENSION pxf_fdw VERSION '1.0'");
         regress.runSqlTest("features/fdw_extension_tests/create_extension_rpm");
     }
 
-    @Test(groups = {"testcontainers", "pxfFdwExtension"})
+    @Test(groups = {"testcontainers", "pxf-fdw-extension"})
     public void testPxfUpgrade() throws Exception {
         extensionDb.runQuery("CREATE EXTENSION pxf_fdw VERSION '1.0'");
         regress.runSqlTest("features/fdw_extension_tests/upgrade/step_1_create_extension_with_older_pxf_version");
@@ -71,7 +71,7 @@ public class PxfFdwExtensionTest extends AbstractTestcontainersTest {
         regress.runSqlTest("features/fdw_extension_tests/upgrade/step_2_after_alter_extension");
     }
 
-    @Test(groups = {"testcontainers", "pxfFdwExtension"})
+    @Test(groups = {"testcontainers", "pxf-fdw-extension"})
     public void testPxfDowngradeThenUpgradeAgain() throws Exception {
         extensionDb.runQuery("CREATE EXTENSION pxf_fdw VERSION '2.0'");
         regress.runSqlTest("features/fdw_extension_tests/downgrade_then_upgrade/step_1_check_extension");

--- a/ci/docker/pxf-cbdb-dev/common/script/run_tests.sh
+++ b/ci/docker/pxf-cbdb-dev/common/script/run_tests.sh
@@ -504,7 +504,7 @@ generate_test_summary() {
 
     local group=$(basename "$group_dir")
     # Skip if it's not a test group directory
-    [[ "$group" =~ ^(smoke|hcatalog|hcfs|hdfs|hive|gpdb|sanity|hbase|profile|jdbc|proxy|unused|features|load|performance|pxfExtension|pxfFdwExtension|fdw|gpdb_fdw)$ ]] || continue
+    [[ "$group" =~ ^(smoke|hcatalog|hcfs|hdfs|hive|gpdb|sanity|hbase|profile|jdbc|proxy|unused|features|load|performance|fdw|gpdb_fdw)$ ]] || continue
 
     echo "Processing $group test reports from $group_dir"
 

--- a/ci/docker/pxf-cbdb-dev/common/script/run_tests.sh
+++ b/ci/docker/pxf-cbdb-dev/common/script/run_tests.sh
@@ -408,43 +408,6 @@ gpdb_test() {
   echo "[run_tests] GROUP=gpdb $extra_args finished"
 }
 
-pxf_extension_test(){
-  local sudo_cmd=""
-  if [ "$(id -u)" -ne 0 ]; then
-    sudo_cmd="sudo -n"
-  fi
-  local extension_dir="${GPHOME}/share/postgresql/extension"
-  local pxf_fdw_control="${extension_dir}/pxf_fdw.control"
-  if [ -d "${REPO_ROOT}/fdw" ] && [ -d "${extension_dir}" ]; then
-    for sql in pxf_fdw--2.0.sql pxf_fdw--1.0--2.0.sql pxf_fdw--2.0--1.0.sql; do
-      if [ -f "${REPO_ROOT}/fdw/${sql}" ]; then
-        ${sudo_cmd} cp -f "${REPO_ROOT}/fdw/${sql}" "${extension_dir}/${sql}"
-      fi
-    done
-  fi
-
-  set_pxf_fdw_default_version() {
-    local version="$1"
-    if [ -f "${pxf_fdw_control}" ]; then
-      ${sudo_cmd} sed -i "s/^default_version = '.*'/default_version = '${version}'/" "${pxf_fdw_control}"
-    fi
-  }
-
-  set_pxf_fdw_default_version "2.0"
-  make GROUP="pxfExtensionVersion2" || true
-  save_test_reports "pxfExtensionVersion2"
-  make GROUP="pxfExtensionVersion2_1" || true
-  save_test_reports "pxfExtensionVersion2_1"
-
-  set_pxf_fdw_default_version "1.0"
-  make GROUP="pxfFdwExtensionVersion1" || true
-  save_test_reports "pxfFdwExtensionVersion1"
-
-  set_pxf_fdw_default_version "2.0"
-  make GROUP="pxfFdwExtensionVersion2" || true
-  save_test_reports "pxfFdwExtensionVersion2"
-}
-
 bench_prepare_env() {
   export HADOOP_HEAPSIZE=${HADOOP_HEAPSIZE:-2048}
   export JAVA_HOME="${JAVA_HADOOP}"
@@ -541,7 +504,7 @@ generate_test_summary() {
 
     local group=$(basename "$group_dir")
     # Skip if it's not a test group directory
-    [[ "$group" =~ ^(smoke|hcatalog|hcfs|hdfs|hive|gpdb|sanity|hbase|profile|jdbc|proxy|unused|features|load|performance|pxfExtensionVersion2|pxfExtensionVersion2_1|pxfFdwExtensionVersion1|pxfFdwExtensionVersion2|fdw|gpdb_fdw)$ ]] || continue
+    [[ "$group" =~ ^(smoke|hcatalog|hcfs|hdfs|hive|gpdb|sanity|hbase|profile|jdbc|proxy|unused|features|load|performance|pxfExtension|pxfFdwExtension|fdw|gpdb_fdw)$ ]] || continue
 
     echo "Processing $group test reports from $group_dir"
 
@@ -705,9 +668,6 @@ run_single_group() {
     gpdb)
       gpdb_test "false"
       ;;
-    pxf_extension)
-      pxf_extension_test
-      ;;
     load)
       bench_prepare_env
       load_test
@@ -729,7 +689,7 @@ run_single_group() {
       ;;
     *)
       echo "Unknown test group: $group"
-      echo "Available groups: cli, external-table, fdw, server, sanity, smoke, hdfs, hcatalog, hcfs, hive, hbase, profile, jdbc, proxy, unused, features, gpdb, gpdb_fdw, load, performance, bench, pxf_extension"
+      echo "Available groups: cli, external-table, fdw, server, sanity, smoke, hdfs, hcatalog, hcfs, hive, hbase, profile, jdbc, proxy, unused, features, gpdb, gpdb_fdw, load, performance, bench"
       exit 1
       ;;
   esac


### PR DESCRIPTION
Use TestContainers for "pxf_extension" test group:
1. use TestContainers
2. explicitly specify extension version - so, there is no need in SQL file manipulation
3. remove 'SELECT' from test - we don't care about external-table 2.0 (pre PXF 6.7).