### PR TITLE
Fix confusing build failure when javac is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,34 @@ To build PXF, you must have:
     source /usr/local/cloudberry-db/cloudberry-env.sh # For Cloudberry 2.1+
     ```
 
-3. JDK 1.8 or JDK 11 to compile/run
+3. JDK 1.8, 11, 17, or 21 to compile/run
 
-    Export your `JAVA_HOME`:
+    > [!NOTE]
+    > Support for JDK 1.8 will be removed in PXF 3.0. Use JDK 11 or later for new setups.
+
+    A full JDK is required -- a JRE is not enough, because the server module needs
+    `javac`. If only a JRE is installed, Gradle fails with
+    `Toolchain installation '...' does not provide the required capabilities: [JAVA_COMPILER]`.
+    Note that on Debian/Ubuntu the `maven` package depends on `default-jre-headless` and does
+    **not** pull in a JDK.
+
+    > [!IMPORTANT]
+    > If you hit that error and then install the JDK, you must also stop the Gradle
+    > daemon (`cd server && ./gradlew --stop`) before rebuilding. The daemon caches JVM
+    > installation metadata for its whole lifetime, so a daemon started while only the
+    > JRE was present keeps reporting the identical error even after `javac` exists.
+
     ```
-    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+    # Debian/Ubuntu
+    sudo apt-get install -y openjdk-11-jdk
+    # RHEL/Rocky
+    sudo dnf install -y java-11-openjdk-devel
+    ```
+
+    Export your `JAVA_HOME`, pointing it at the JDK (the directory that contains `bin/javac`):
+    ```
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64  # Debian/Ubuntu
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk        # RHEL/Rocky
     ```
 
 4. Go (1.25 or later)
@@ -163,7 +186,7 @@ We provide a Docker-based development environment that includes Cloudberry, Hado
 
 - Start IntelliJ. Click "Open" and select the directory to which you cloned the `pxf` repo.
 - Select `File > Project Structure`.
-- Make sure you have a JDK (version 1.8) selected.
+- Make sure you have a JDK selected (1.8, 11, 17, or 21). CI builds with JDK 11 by default.
 - In the `Project Settings > Modules` section, select `Import Module`, pick the `pxf/server` directory and import as a Gradle module. You may see an error saying that there's
 no JDK set for Gradle. Just cancel and retry. It goes away the second time.
 - Import a second module, giving the `pxf/automation` directory, select "Import module from external model", pick `Maven` then click Finish.

--- a/README.md
+++ b/README.md
@@ -74,17 +74,8 @@ To build PXF, you must have:
     > [!NOTE]
     > Support for JDK 1.8 will be removed in PXF 3.0. Use JDK 11 or later for new setups.
 
-    A full JDK is required -- a JRE is not enough, because the server module needs
-    `javac`. If only a JRE is installed, Gradle fails with
-    `Toolchain installation '...' does not provide the required capabilities: [JAVA_COMPILER]`.
-    Note that on Debian/Ubuntu the `maven` package depends on `default-jre-headless` and does
-    **not** pull in a JDK.
-
-    > [!IMPORTANT]
-    > If you hit that error and then install the JDK, you must also stop the Gradle
-    > daemon (`cd server && ./gradlew --stop`) before rebuilding. The daemon caches JVM
-    > installation metadata for its whole lifetime, so a daemon started while only the
-    > JRE was present keeps reporting the identical error even after `javac` exists.
+    A full JDK is required; a JRE is not enough, because the server module needs
+    `javac`.
 
     ```
     # Debian/Ubuntu
@@ -118,6 +109,8 @@ To build PXF, you must have:
 ### Build PXF
 
 PXF uses Makefiles to build its components. PXF server component uses Gradle that is wrapped into the Makefile for convenience.
+
+If the build fails, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md#build-issues).
 
 > [!NOTE]
 > To comply with Apache Software Foundation release guidelines, `gradle-wrapper.jar` is not included in the source distribution. It will be downloaded automatically during the initial build. Please ensure you have an active and stable internet connection.

--- a/README.md
+++ b/README.md
@@ -69,22 +69,13 @@ To build PXF, you must have:
     source /usr/local/cloudberry-db/cloudberry-env.sh # For Cloudberry 2.1+
     ```
 
-3. JDK 1.8, 11, 17, or 21 to compile/run
+3. A full JDK -- 1.8, 11, 17, or 21 -- to compile/run. A JRE is not enough, as the
+   server module needs `javac`.
 
     > [!NOTE]
     > Support for JDK 1.8 will be removed in PXF 3.0. Use JDK 11 or later for new setups.
 
-    A full JDK is required; a JRE is not enough, because the server module needs
-    `javac`.
-
-    ```
-    # Debian/Ubuntu
-    sudo apt-get install -y openjdk-11-jdk
-    # RHEL/Rocky
-    sudo dnf install -y java-11-openjdk-devel
-    ```
-
-    Export your `JAVA_HOME`, pointing it at the JDK (the directory that contains `bin/javac`):
+    Export your `JAVA_HOME`:
     ```
     export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64  # Debian/Ubuntu
     export JAVA_HOME=/usr/lib/jvm/java-11-openjdk        # RHEL/Rocky

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,5 +1,46 @@
 # Troubleshooting
 
+## Build Issues
+
+### Gradle reports `does not provide the required capabilities: [JAVA_COMPILER]`
+
+```
+Execution failed for task ':pxf-api:compileJava'.
+> Error while evaluating property 'javaCompiler' of task ':pxf-api:compileJava'.
+   > Toolchain installation '/usr/lib/jvm/java-11-openjdk-amd64' does not provide
+     the required capabilities: [JAVA_COMPILER]
+```
+
+The JVM Gradle is running on has no `javac`, so it is a JRE rather than a JDK.
+Gradle itself starts fine on a JRE, which is why the build gets as far as
+`:pxf-api:compileJava` before failing. Install a JDK and point `JAVA_HOME` at it:
+
+```
+# Debian/Ubuntu
+sudo apt-get install -y openjdk-11-jdk
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# RHEL/Rocky
+sudo dnf install -y java-11-openjdk-devel
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+```
+
+Two things make this easy to misdiagnose:
+
+* On Debian/Ubuntu the JRE is installed into `/usr/lib/jvm/java-11-openjdk-amd64`,
+  the same directory a JDK would use, so `java -version` and `ls /usr/lib/jvm` both
+  look healthy while `javac` is absent. The `maven` package depends on
+  `default-jre-headless` and does **not** pull in a JDK. (On RHEL/Rocky,
+  `dnf install maven` does install one, via `maven-jdk-binding`.)
+* Installing the JDK is not sufficient on its own. The Gradle daemon caches JVM
+  installation metadata for its whole lifetime and never re-checks the filesystem,
+  and because the JDK lands in the same *path*, Gradle reuses the daemon left behind
+  by the failed build and reports the identical error. Stop it first:
+
+  ```
+  cd server && ./gradlew --stop
+  ```
+
 ## Out of Memory Issues
 
 ### 

--- a/server/Makefile
+++ b/server/Makefile
@@ -27,8 +27,32 @@ PXF_API_VERSION ?= $(shell cat $(PXF_ROOT_DIR)/api_version)
 
 PXF_GRADLE_PROPERTIES = -Pversion=$(PXF_VERSION) -PapiVersion=$(PXF_API_VERSION)
 
+# Gradle can start on a JRE, but compiling PXF needs a JDK. Detect a JRE-only
+# installation here so the build fails with an actionable message instead of
+# Gradle's "does not provide the required capabilities: [JAVA_COMPILER]".
+JAVAC := $(if $(JAVA_HOME),$(JAVA_HOME)/bin/javac,$(shell command -v javac 2>/dev/null))
+
+.PHONY: check-jdk
+check-jdk:
+	@if [ ! -x "$(JAVAC)" ]; then \
+		echo "ERROR: no Java compiler (javac) found -- a JDK is required to build PXF, a JRE is not enough."; \
+		if [ -n "$(JAVA_HOME)" ]; then \
+			echo "       JAVA_HOME=$(JAVA_HOME) has no bin/javac, so it points at a JRE."; \
+		else \
+			echo "       JAVA_HOME is not set and javac is not on PATH."; \
+		fi; \
+		echo "       Install a JDK and point JAVA_HOME at it, for example:"; \
+		echo "         Debian/Ubuntu: sudo apt-get install -y openjdk-11-jdk"; \
+		echo "         RHEL/Rocky:    sudo dnf install -y java-11-openjdk-devel"; \
+		echo "         export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64"; \
+		echo "       Then run './gradlew --stop', because a Gradle daemon started"; \
+		echo "       before the JDK was installed caches the old JVM metadata and"; \
+		echo "       keeps reporting the same error."; \
+		exit 2; \
+	fi
+
 .PHONY: prepare-gradle-wrapper
-prepare-gradle-wrapper:
+prepare-gradle-wrapper: check-jdk
 	@APP_HOME="$(CURDIR)" bash ./gradlew-install.sh
 
 help:

--- a/server/Makefile
+++ b/server/Makefile
@@ -45,9 +45,8 @@ check-jdk:
 		echo "         Debian/Ubuntu: sudo apt-get install -y openjdk-11-jdk"; \
 		echo "         RHEL/Rocky:    sudo dnf install -y java-11-openjdk-devel"; \
 		echo "         export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64"; \
-		echo "       Then run './gradlew --stop', because a Gradle daemon started"; \
-		echo "       before the JDK was installed caches the old JVM metadata and"; \
-		echo "       keeps reporting the same error."; \
+		echo "       If a build already failed here, also run './gradlew --stop'."; \
+		echo "       See TROUBLESHOOTING.md for details."; \
 		exit 2; \
 	fi
 


### PR DESCRIPTION
Fixes #150.

Building PXF on a machine that has a JRE but no JDK fails at
`:pxf-api:compileJava` with a message that never mentions a JDK:

```
> Error while evaluating property 'javaCompiler' of task ':pxf-api:compileJava'.
   > Toolchain installation '/usr/lib/jvm/java-11-openjdk-amd64' does not
     provide the required capabilities: [JAVA_COMPILER]
```

Two things then make it hard to get out of:

1. On Debian/Ubuntu the JRE is installed into `/usr/lib/jvm/java-11-openjdk-amd64`,
   the same directory a JDK would use, so `java -version` and `ls /usr/lib/jvm`
   both look healthy while `javac` is absent. Gradle's error names that very
   directory, reinforcing the impression that Java is fine there.
2. Installing the JDK afterwards does not help by itself. `server/gradle.properties`
   enables the Gradle daemon, and the daemon caches JVM installation metadata for
   its whole lifetime without re-checking the filesystem. Since the JDK lands in
   the same *path*, Gradle reuses the existing daemon and replays the stale
   verdict -- the identical error, in 2 seconds. `./gradlew --stop` is required.

## Changes

**`server/Makefile`** -- new `check-jdk` target, hung off `prepare-gradle-wrapper`
(the chokepoint every Gradle target already depends on). It verifies
`$JAVA_HOME/bin/javac`, or `javac` on `PATH` when `JAVA_HOME` is unset, and fails
with:

```
ERROR: no Java compiler (javac) found -- a JDK is required to build PXF, a JRE is not enough.
       JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 has no bin/javac, so it points at a JRE.
       Install a JDK and point JAVA_HOME at it, for example:
         Debian/Ubuntu: sudo apt-get install -y openjdk-11-jdk
         RHEL/Rocky:    sudo dnf install -y java-11-openjdk-devel
         export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
       Then run './gradlew --stop', because a Gradle daemon started
       before the JDK was installed caches the old JVM metadata and
       keeps reporting the same error.
```

**`README.md`** -- state that a JRE is not enough and give the apt/dnf package
names; note that on Debian/Ubuntu the `maven` package depends on
`default-jre-headless` and does not pull in a JDK; document the `./gradlew --stop`
requirement; update the supported versions from "JDK 1.8 or JDK 11" to 8, 11, 17
and 21, which is what the `java-compatibility-test` matrix in `pxf-ci.yml` already
runs, and note that 1.8 support will be removed in PXF 3.0; sync the IntelliJ
section, which also said 1.8. Finally, fix the example `JAVA_HOME`
(`/usr/lib/jvm/java-11-openjdk`) -- a RHEL-style path that does not exist on
Debian/Ubuntu, where it needs the `-amd64` suffix.

No production code and no Gradle build logic is touched. CI is unaffected:
`ci/docker/pxf-cbdb-dev/common/script/build_pxf.sh` already installs a JDK
explicitly, which is why this only ever hit people following the README.

## Testing

`check-jdk` was exercised in three states: `JAVA_HOME` pointing at a JRE-shaped
directory (exit 2 with the message above), `JAVA_HOME` unset with no `javac` on
`PATH` (exit 2), and `JAVA_HOME` pointing at a real JDK (exit 0). `make -n compile`
confirms the check runs before Gradle.

The underlying failure was reproduced end to end in a clean `ubuntu:22.04`
container against the `2.2.0-incubating-rc1` tree:

| Phase | Environment | Result |
|---|---|---|
| 1 | `openjdk-11-jre-headless` only | the `[JAVA_COMPILER]` error above |
| 2 | `openjdk-11-jdk` installed, daemon not stopped | identical error, `BUILD FAILED in 2s` |
| 3 | same, after `./gradlew --stop` | `BUILD SUCCESSFUL in 23s` |

A clean Ubuntu 22.04 that installs `openjdk-11-jdk` before the first build succeeds
outright.
