### PR TITLE
CI: bump gradle/actions/dependency-submission to v6.3.0

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: ./server
         run: make prepare-gradle-wrapper
       - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0
+        uses: gradle/actions/dependency-submission@9c971963bec38e04b3d30dcc455b5382be2fdbfb  # v6.3.0
         with:
           build-root-directory: server
           artifact-retention-days: 5


### PR DESCRIPTION
The pinned v6.1.0 SHA is not in the ASF allowed-actions list, so the Dependency Submission job is blocked on every push to main. v6.3.0 is the only entry for this action without an expires_at, so it will not need another bump on a schedule.


https://github.com/apache/infrastructure-actions/blob/ec1b354a0455b41001d77473236d02a0ee0adba4/actions.yml#L575-L580

<!--Thank you for contributing! -->

<!--In case of an existing issue or discussions, please reference it-->
closes: #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Learn the [code contribution](https://cloudberry.apache.org/contribute/code) and [doc contribution](https://cloudberry.apache.org/contribute/doc) guides for better collaboration.
* Make sure that CICD workflow is successful.
* List your communications in the [GitHub Issues](https://github.com/apache/cloudberry-pxf/issues) or [Discussions](https://github.com/apache/cloudberry/discussions) (if has or needed).
* Feel free to ask for the [cloudberry committers](https://github.com/orgs/apache/teams/cloudberry-committers) or other people to help review and approve.